### PR TITLE
Changes to validation of catchupThreshold.

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -446,14 +446,12 @@ namespace Mirror
             // make sure that catchup threshold is > buffer multiplier.
             // for a buffer multiplier of '3', we usually have at _least_ 3
             // buffered snapshots. often 4-5 even.
-            // catchUpThreshold should be a minimum of 4, to prevent clashes with
-            // SnapshotInterpolation looking for at least 3 old enough buffers, else
-            // catch up will be implemented while there is not enough old buffers,
-            // and will result in jitter. 
-            // catchupThreshold should be at least bufferTimeMultiplier + 2 because
-            // the first 2 snapshots are used for interpolation, and catch up should start
-            // only if we have those 2 used snapshots + buffered snapshots.
-            catchupThreshold = Mathf.Max(bufferTimeMultiplier + 2, catchupThreshold, 4);
+            // catchUpThreshold should be a minimum of bufferTimeMultiplier + 3, 
+            // to prevent clashes with SnapshotInterpolation looking for at least 
+            // 3 old enough buffers, else catch up will be implemented while there 
+            // is not enough old buffers, and will result in jitter. 
+            
+            catchupThreshold = Mathf.Max(bufferTimeMultiplier + 3, catchupThreshold);
 
             // buffer limit should be at least multiplier to have enough in there
             bufferSizeLimit = Mathf.Max(bufferTimeMultiplier, bufferSizeLimit);

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -446,7 +446,7 @@ namespace Mirror
             // make sure that catchup threshold is > buffer multiplier.
             // for a buffer multiplier of '3', we usually have at _least_ 3
             // buffered snapshots. often 4-5 even.
-            catchupThreshold = Mathf.Max(bufferTimeMultiplier + 1, catchupThreshold);
+            catchupThreshold = Mathf.Max(bufferTimeMultiplier + 2, catchupThreshold, 4);
 
             // buffer limit should be at least multiplier to have enough in there
             bufferSizeLimit = Mathf.Max(bufferTimeMultiplier, bufferSizeLimit);

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -446,11 +446,12 @@ namespace Mirror
             // make sure that catchup threshold is > buffer multiplier.
             // for a buffer multiplier of '3', we usually have at _least_ 3
             // buffered snapshots. often 4-5 even.
+            //
             // catchUpThreshold should be a minimum of bufferTimeMultiplier + 3, 
             // to prevent clashes with SnapshotInterpolation looking for at least 
             // 3 old enough buffers, else catch up will be implemented while there 
             // is not enough old buffers, and will result in jitter. 
-            
+            // (validated with several real world tests by ninja & imer)
             catchupThreshold = Mathf.Max(bufferTimeMultiplier + 3, catchupThreshold);
 
             // buffer limit should be at least multiplier to have enough in there

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -446,6 +446,13 @@ namespace Mirror
             // make sure that catchup threshold is > buffer multiplier.
             // for a buffer multiplier of '3', we usually have at _least_ 3
             // buffered snapshots. often 4-5 even.
+            // catchUpThreshold should be a minimum of 4, to prevent clashes with
+            // SnapshotInterpolation looking for at least 3 old enough buffers, else
+            // catch up will be implemented while there is not enough old buffers,
+            // and will result in jitter. 
+            // catchupThreshold should be at least bufferTimeMultiplier + 2 because
+            // the first 2 snapshots are used for interpolation, and catch up should start
+            // only if we have those 2 used snapshots + buffered snapshots.
             catchupThreshold = Mathf.Max(bufferTimeMultiplier + 2, catchupThreshold, 4);
 
             // buffer limit should be at least multiplier to have enough in there


### PR DESCRIPTION
catchupThreshold needs to be at least 4, or it will interfere/conflict with checking if we have at least 3 old enough buffers. Catchup will decrease buffer while check needs at least 3 older.
catchupThreshold should also at least be bufferTimeMultiplier + 2, to take into account of the first 2 snapshots which is used for interpolation, before trying to implement catch up.