### PR TITLE
Fix - From !isLocalPlayer to !hasAuthority - NetworkTransform2k - NetworkTransformBase.cs

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -285,7 +285,7 @@ namespace Mirror
             // -> don't apply for host mode player either, even if in
             //    client authority mode. if it doesn't go over the network,
             //    then we don't need to do anything.
-            if (clientAuthority && !isLocalPlayer)
+            if (clientAuthority && !hasAuthority)
             {
                 // compute snapshot interpolation & apply if any was spit out
                 // TODO we don't have Time.deltaTime double yet. float is fine.

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -282,7 +282,7 @@ namespace Mirror
             // apply buffered snapshots IF client authority
             // -> in server authority, server moves the object
             //    so no need to apply any snapshots there.
-            // -> don't apply for host mode player either, even if in
+            // -> don't apply for host mode player objects either, even if in
             //    client authority mode. if it doesn't go over the network,
             //    then we don't need to do anything.
             if (clientAuthority && !hasAuthority)


### PR DESCRIPTION
Changed !isLocalPlayer to !hasAuthority because object might not be player object.