### PR TITLE
Fix - delayed movement in clients in ClientAuthority mode - NetworkTr…

### DIFF
--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -152,7 +152,7 @@ namespace Mirror
             OnClientToServerSync(position, rotation, scale);
             //For client authority, immediately pass on the client snapshot to all other
             //clients instead of waiting for server to send its snapshots.
-            if(clientAuthority)
+            if (clientAuthority)
             {
                 RpcServerToClientSync(position, rotation, scale);
             }

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -280,7 +280,8 @@ namespace Mirror
             // since host does not send anything to update the server, any client
             // authoritative movement done by the host will have to be broadcasted 
             // here by checking IsClientWithAuthority.
-            if (NetworkTime.localTime >= lastServerSendTime + sendInterval && (!clientAuthority || IsClientWithAuthority))
+            if (NetworkTime.localTime >= lastServerSendTime + sendInterval && 
+                (!clientAuthority || IsClientWithAuthority))
             {
                 // send snapshot without timestamp.
                 // receiver gets it from batch timestamp to save bandwidth.

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -147,8 +147,16 @@ namespace Mirror
         // cmd /////////////////////////////////////////////////////////////////
         // only unreliable. see comment above of this file.
         [Command(channel = Channels.Unreliable)]
-        void CmdClientToServerSync(Vector3? position, Quaternion? rotation, Vector3? scale) =>
+        void CmdClientToServerSync(Vector3? position, Quaternion? rotation, Vector3? scale)
+        {
             OnClientToServerSync(position, rotation, scale);
+            //For client authority, immediately pass on the client snapshot to all other
+            //clients instead of waiting for server to send it's snapshots.
+            if(clientAuthority)
+            {
+                RpcServerToClientSync(position, rotation, scale);
+            }
+        }
 
         // local authority client sends sync message to server for broadcasting
         protected virtual void OnClientToServerSync(Vector3? position, Quaternion? rotation, Vector3? scale)
@@ -264,7 +272,15 @@ namespace Mirror
             // DO NOT send nulls if not changed 'since last send' either. we
             // send unreliable and don't know which 'last send' the other end
             // received successfully.
-            if (NetworkTime.localTime >= lastServerSendTime + sendInterval)
+            // 
+            // Checks to ensure server only sends snapshots if object is
+            // on server authority(!clientAuthority) mode because on client 
+            // authority mode snapshots are broadcasted right after the authoritative 
+            // client updates server in the command function(see above), OR,
+            // since host does not send anything to update the server, any client
+            // authoritative movement done by the host will have to be broadcasted 
+            // here by checking IsClientWithAuthority.
+            if (NetworkTime.localTime >= lastServerSendTime + sendInterval && (!clientAuthority || IsClientWithAuthority))
             {
                 // send snapshot without timestamp.
                 // receiver gets it from batch timestamp to save bandwidth.

--- a/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
+++ b/Assets/Mirror/Components/NetworkTransform2k/NetworkTransformBase.cs
@@ -151,7 +151,7 @@ namespace Mirror
         {
             OnClientToServerSync(position, rotation, scale);
             //For client authority, immediately pass on the client snapshot to all other
-            //clients instead of waiting for server to send it's snapshots.
+            //clients instead of waiting for server to send its snapshots.
             if(clientAuthority)
             {
                 RpcServerToClientSync(position, rotation, scale);


### PR DESCRIPTION
…ansformBase.cs

Fixed issue where clients experience delayed movement in client authority mode.
Problem: Clients update the server first, server builds buffer then moves object, and then sends server's current snapshot to all the other clients who then build their buffers first before moving. This results in delayed movement in clients.
Changed the process to pass on the snapshot which the authoritative client updates the server onwards to other clients immediately instead and added checks to ensure server only broadcasts when object is on server authority or on host client authority.