### PR TITLE
Fix ArgumentExceptionError when adding snapshot to buffer - SnapshotI…

### DIFF
--- a/Assets/Mirror/Runtime/SnapshotInterpolation/SnapshotInterpolation.cs
+++ b/Assets/Mirror/Runtime/SnapshotInterpolation/SnapshotInterpolation.cs
@@ -40,7 +40,9 @@ namespace Mirror
                 return;
 
             // otherwise sort it into the list
-            buffer.Add(timestamp, snapshot);
+            // as long as buffer does not already contain it.
+            if(!buffer.ContainsKey(timestamp))                
+                buffer.Add(timestamp, snapshot);
         }
 
         // helper function to check if we have >= n old enough snapshots.


### PR DESCRIPTION
…nterpolation.cs

Occassionally duplicate messages may be received with the same remoteTimestamp. Adding an already existing key to buffer (Sorted List) will throw an ArgumentExceptionError and disconnect the client from the server.
Fixed by adding an if check to add snapshot only if remoteTimestamp key does not exist in the buffer.